### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samkeen/llm-bridge/releases/tag/v0.1.0) - 2024-05-27
+
+### Fixed
+- fixed tests and some project renaming artifacts
+- fixed type for ResponseMessage.content
+
+### Other
+- Merge pull request [#4](https://github.com/samkeen/llm-bridge/pull/4) from samkeen/release-plz-2024-04-27T21-17-32Z
+- release
+- .gitignore cleanup
+- Merge branch 'main' into release-plz-2024-04-27T19-50-08Z
+- release
+- Capturing more fields in API response
+- project name change
+- Merge branch 'main' into release-plz-2024-04-19T03-15-29Z
+- release
+- Swithed to builder pattern for send_message
+- added `first_message` fn to `ResponseMessage`
+- release
+- improved error handling on Client.send_message
+- added repository link to Cargo file
+- docs update
+- init commit
+- init commit


### PR DESCRIPTION
## 🤖 New release
* `llm-bridge`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/samkeen/llm-bridge/releases/tag/v0.1.0) - 2024-05-27

### Fixed
- fixed tests and some project renaming artifacts
- fixed type for ResponseMessage.content

### Other
- Merge pull request [#4](https://github.com/samkeen/llm-bridge/pull/4) from samkeen/release-plz-2024-04-27T21-17-32Z
- release
- .gitignore cleanup
- Merge branch 'main' into release-plz-2024-04-27T19-50-08Z
- release
- Capturing more fields in API response
- project name change
- Merge branch 'main' into release-plz-2024-04-19T03-15-29Z
- release
- Swithed to builder pattern for send_message
- added `first_message` fn to `ResponseMessage`
- release
- improved error handling on Client.send_message
- added repository link to Cargo file
- docs update
- init commit
- init commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).