### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/samkeen/llm-bridge/compare/v0.1.1...v0.1.2) - 2024-07-09
+
+### Other
+- all dependencies had minor/patch updates
+
 ## [0.1.1](https://github.com/samkeen/llm-bridge/compare/v0.1.0...v0.1.1) - 2024-05-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llm-bridge"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-bridge"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Sam Keen <sam.sjk@gmail.com>"]
 description = "SDK for interacting with various Large Language Model (LLM) APIs using a common interface"


### PR DESCRIPTION
## 🤖 New release
* `llm-bridge`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/samkeen/llm-bridge/compare/v0.1.1...v0.1.2) - 2024-07-09

### Other
- all dependencies had minor/patch updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).