### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/samkeen/llm-bridge/compare/v0.1.2...v0.2.0) - 2024-07-28
+
+### Added
+- add tool use support
+
 ## [0.1.2](https://github.com/samkeen/llm-bridge/compare/v0.1.1...v0.1.2) - 2024-07-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llm-bridge"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-bridge"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sam Keen <sam.sjk@gmail.com>"]
 description = "SDK for interacting with various Large Language Model (LLM) APIs using a common interface"


### PR DESCRIPTION
## 🤖 New release
* `llm-bridge`: 0.1.2 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/samkeen/llm-bridge/compare/v0.1.2...v0.2.0) - 2024-07-28

### Added
- add tool use support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).